### PR TITLE
#25 ReadOnly mode when opening Excel files

### DIFF
--- a/jxls-poi/src/test/java/org/jxls/TestWorkbook.java
+++ b/jxls-poi/src/test/java/org/jxls/TestWorkbook.java
@@ -22,7 +22,7 @@ public class TestWorkbook implements AutoCloseable {
     
     public TestWorkbook(File file) {
         try {
-            workbook = WorkbookFactory.create(file);
+            workbook = WorkbookFactory.create(file, null, true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
only needed for TestWorkbook

Users of WorkbookFactory should know that you should not use

WorkbookFactory.create(file)

for opening a Excel template. Use instead the read-only access mode:

WorkbookFactory.create(file, null, true)