### PR TITLE
#79 Multi-line and comment support: removed unnecessary checking, cre…

### DIFF
--- a/jxls/src/main/java/org/jxls/extractors/LiteralsExtractor.java
+++ b/jxls/src/main/java/org/jxls/extractors/LiteralsExtractor.java
@@ -8,6 +8,10 @@ import java.util.Stack;
 
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
 
+/**
+ * @author Alexander Lust
+ */
+
 public class LiteralsExtractor {
     public static final int COMMAND_PREFIX_LENGTH = 3;
     private String text;
@@ -21,7 +25,7 @@ public class LiteralsExtractor {
     public List<String> extract() {
         String literal = "";
         for (int i = 0, n = text.length(); i < n; i++) {
-            if (literal.length() >= COMMAND_PREFIX_LENGTH && literal.endsWith(XlsCommentAreaBuilder.COMMAND_PREFIX)) {
+            if (literal.endsWith(XlsCommentAreaBuilder.COMMAND_PREFIX)) {
                 // if the first 3 chars of literal are 'jx:'
                 // save comment parsed before
                 literal = literal.substring(0, literal.length() - COMMAND_PREFIX_LENGTH);

--- a/jxls/src/test/java/org/jxls/extractors/LiteralsExtractorTest.java
+++ b/jxls/src/test/java/org/jxls/extractors/LiteralsExtractorTest.java
@@ -1,0 +1,62 @@
+package org.jxls.extractors;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.jxls.extractors.LiteralsExtractor;
+
+/**
+ * @author Alexander Lust
+ */
+
+public class LiteralsExtractorTest {
+
+    /**
+     * Tests whether the LiteralsExtractor is used correctly.
+     */	
+	@Test
+    public void testExtract() {
+    	List<String> literalList = new ArrayList<String>();
+    	String expectedText = "jx:each(items=\"jdbc.query('select * \r\n"
+    			+ "-- comment 1\r\n"
+    			+ "\r\n"
+    			+ "/*\r\n"
+    			+ "coment2\r\n"
+    			+ "\r\n"
+    			+ "comment3\r\n"
+    			+ "\r\n"
+    			+ "*/\r\n"
+    			+ "from RS_USER')\" var=\"user\" lastCell=\"D4\")";
+    	
+    	String text = "Autor:\r\n"
+    			+ "jx:each(items=\"jdbc.query('select * \r\n"
+    			+ "-- comment 1\r\n"
+    			+ "\r\n"
+    			+ "/*\r\n"
+    			+ "coment2\r\n"
+    			+ "\r\n"
+    			+ "comment3\r\n"
+    			+ "\r\n"
+    			+ "*/\r\n"
+    			+ "from RS_USER')\" var=\"user\" lastCell=\"D4\")";
+        LiteralsExtractor extractor = new LiteralsExtractor(text, literalList);
+        literalList = extractor.extract();
+        
+        assertEquals("Number of literalList is wrong", 2, literalList.size());
+        assertEquals("First member of literalList is wrong", "Autor:\r", literalList.get(0));
+        assertEquals("Second member of literalList is wrong", expectedText, literalList.get(1));
+    }
+	
+    /**
+     * Tests null.
+     */	
+	@Test(expected = NullPointerException.class)
+    public void testNullPointerException() {
+    	List<String> literalList = null;
+    	String text = null;
+        LiteralsExtractor extractor = new LiteralsExtractor(text, literalList);
+        literalList = extractor.extract();
+    }
+    
+}


### PR DESCRIPTION
Hi, I adjusted, tested and checked the source code again. Now the changes based on the branch feature-79-fixes-2.

1. Yes, you can remove „literal.length() >= COMMAND_PREFIX_LENGTH &&“ You're right.
2. I wrote a JUnit-test for LiteralsExtractor

Best regards,

Alexanmder Lust