### PR TITLE
issue #153 - fixed processing of static cells for every row in XLS area

### DIFF
--- a/jxls-site/src/site/markdown/changes.md
+++ b/jxls-site/src/site/markdown/changes.md
@@ -3,7 +3,8 @@ Version History
 
 v2.12.0
 --------
-* [#147 Row height bugfix], contribution by [jools-uk](https://github.com/jools-uk)
+* [#147 Row height bugfix](https://github.com/jxlsteam/jxls/issues/147), contribution by [jools-uk](https://github.com/jools-uk)
+* [#153 Issue in Excel Output while using SXSSF Transformer](https://github.com/jxlsteam/jxls/issues/153)
 
 
 v2.11.0

--- a/jxls-site/src/site/markdown/index.md
+++ b/jxls-site/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+Jxls 2.12.0 is released!
+============================
+
+* [#147 Row height bugfix](https://github.com/jxlsteam/jxls/issues/147), contribution by [jools-uk](https://github.com/jools-uk)
+* [#153 Issue in Excel Output while using SXSSF Transformer](https://github.com/jxlsteam/jxls/issues/153)
+
+
 Jxls 2.11.0 is available!
 ============================
 

--- a/jxls/src/main/java/org/jxls/common/CellRange.java
+++ b/jxls/src/main/java/org/jxls/common/CellRange.java
@@ -175,7 +175,7 @@ public class CellRange {
     }
 
     public boolean isExcluded(int row, int col) {
-        return cells[row][col] == null || CellRef.NONE.equals(cells[row][col]);
+        return !contains(row, col) || cells[row][col] == null || CellRef.NONE.equals(cells[row][col]);
     }
 
     public boolean contains(int row, int col){
@@ -184,7 +184,7 @@ public class CellRange {
 
     public boolean containsCommandsInRow(int row) {
         for (int col = 0; col < width; col++) {
-            if (cells[row][col] == null || cells[row][col] == CellRef.NONE) {
+            if ( isExcluded(row, col) ){
                 return true;
             }
         }


### PR DESCRIPTION
Updated area processing to transform static cells in every row where a command is located.
It is not a perfect solution as it omits the static cells that may be located between multiple commands in a single row. 
But it should fix the issues like issue #153.