### PR TITLE
Issue #235 POI 5.2.3

### DIFF
--- a/jxls-poi/build.gradle
+++ b/jxls-poi/build.gradle
@@ -1,12 +1,11 @@
 dependencies {
     implementation project(':jxls')
     
-    implementation 'org.apache.poi:poi-ooxml:4.1.2'
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
+    implementation 'org.apache.commons:commons-compress:1.22'
     implementation 'org.slf4j:jcl-over-slf4j:1.7.30'
     
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.2'
-    testImplementation 'org.apache.poi:ooxml-schemas:1.4'
     testImplementation 'org.mockito:mockito-core:4.3.1'
     testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
     testImplementation 'cglib:cglib-nodep:3.3.0'

--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>2.12.1-SNAPSHOT</version>
+		<version>2.13.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>
@@ -11,7 +11,7 @@
 	<description>Apache POI based Transformer implementation for Jxls library</description>
 
 	<properties>
-		<poi.version>4.1.2</poi.version>
+		<poi.version>5.2.3</poi.version>
 	</properties>
 
 	<dependencies>
@@ -41,18 +41,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.22</version>
 			<scope>runtime</scope>
         </dependency>
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>ooxml-schemas</artifactId>
-			<version>1.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/jxls-poi/src/main/java/org/jxls/transform/poi/PoiCellData.java
+++ b/jxls-poi/src/main/java/org/jxls/transform/poi/PoiCellData.java
@@ -181,9 +181,10 @@ public class PoiCellData extends org.jxls.common.CellData {
     }
 
     private void updateCellGeneralInfo(Cell cell) {
-        if (targetCellType != CellType.FORMULA) {
-            cell.setCellType(getPoiCellType(targetCellType));
-        }
+        // Removed as cell.setCellType is deprecated & cell.setCellValue will set the proper cellType
+        // if (targetCellType != CellType.FORMULA) {
+        //     cell.setCellType(getPoiCellType(targetCellType));
+        // }
         if (hyperlink != null) {
             cell.setHyperlink(hyperlink);
         }
@@ -249,7 +250,8 @@ public class PoiCellData extends org.jxls.common.CellData {
                 cell.setCellErrorValue((Byte) evaluationResult);
                 break;
             case BLANK:
-                cell.setCellType(org.apache.poi.ss.usermodel.CellType.BLANK);
+                // Modiifed as setCellType is deprecated
+                cell.setBlank();
                 break;
         }
     }
@@ -278,7 +280,8 @@ public class PoiCellData extends org.jxls.common.CellData {
             try {
                 String formulaString = evaluationResult.toString();
                 logger.error("Failed to set cell formula " + formulaString + " for cell " + this.toString(), e);
-                cell.setCellType(org.apache.poi.ss.usermodel.CellType.STRING);
+                // Not required as setCellValue will set the cellType to STRING
+                // cell.setCellType(org.apache.poi.ss.usermodel.CellType.STRING);
                 cell.setCellValue(formulaString);
             } catch (Exception ex) {
                 logger.warn("Failed to convert formula to string for cell " + this.toString());

--- a/jxls-poi/src/main/java/org/jxls/transform/poi/PoiTransformer.java
+++ b/jxls-poi/src/main/java/org/jxls/transform/poi/PoiTransformer.java
@@ -259,7 +259,7 @@ public class PoiTransformer extends AbstractTransformer {
         }
         try {
             // conditional formatting
-            destCell.setCellType(CellType.BLANK);
+            destCell.setBlank();  // Modiifed as setCellType is deprecated
             ((PoiCellData) cellData).writeToCell(destCell, context, this);
             copyMergedRegions(cellData, targetCellRef);
         } catch (Exception e) {
@@ -399,7 +399,7 @@ public class PoiTransformer extends AbstractTransformer {
             }
             return;
         }
-        cell.setCellType(CellType.BLANK);
+        cell.setBlank();   // Modiifed as setCellType is deprecated
         cell.setCellStyle(workbook.getCellStyleAt(0));
         if (cell.getCellComment() != null) {
             cell.removeCellComment();

--- a/jxls-poi/src/test/groovy/org/jxls/transform/poi/PoiCellDataTest.groovy
+++ b/jxls-poi/src/test/groovy/org/jxls/transform/poi/PoiCellDataTest.groovy
@@ -233,7 +233,7 @@ class PoiCellDataTest extends Specification{
             hyperlink != null
             hyperlink.address == "http://google.com/"
             wb.getSheetAt(1).getRow(1).getCell(2).getStringCellValue() == "Google"
-            hyperlink.typeEnum == HyperlinkType.URL
+            hyperlink.getType() == HyperlinkType.URL
     }
 
 }

--- a/jxls-poi/src/test/groovy/org/jxls/transform/poi/PoiTransformerTest.groovy
+++ b/jxls-poi/src/test/groovy/org/jxls/transform/poi/PoiTransformerTest.groovy
@@ -129,7 +129,7 @@ class PoiTransformerTest extends Specification{
         then:
             Sheet sheet = wb.getSheet("sheet 2")
             Row row7 = sheet.getRow(7)
-            row7.getCell(7).cellTypeEnum == CellType.NUMERIC
+            row7.getCell(7).getCellType() == CellType.NUMERIC
             row7.getCell(7).getNumericCellValue() == 15
     }
 
@@ -142,7 +142,7 @@ class PoiTransformerTest extends Specification{
         then:
             Sheet sheet = wb.getSheet("sheet 2")
             Row row7 = sheet.getRow(7)
-            row7.getCell(7).cellTypeEnum == CellType.FORMULA
+            row7.getCell(7).getCellType() == CellType.FORMULA
             row7.getCell(7).getCellFormula() == "SUM(A1:A3)"
     }
 
@@ -202,7 +202,7 @@ class PoiTransformerTest extends Specification{
         Sheet sheet2 = wb.getSheet("sheet 2")
         sheet2.getRow(0).getCell(1).getNumericCellValue() == 1.5
         Row row10 = sheet2.getRow(10)
-        row10.getCell(1).getCellTypeEnum() == CellType.STRING
+        row10.getCell(1).getCellType() == CellType.STRING
         row10.getCell(1).getStringCellValue() == "Fghij"
     }
 
@@ -306,7 +306,7 @@ class PoiTransformerTest extends Specification{
             poiTransformer.clearCell(new CellRef("'sheet 1'!B1"))
         then:
             def cell = wb.getSheetAt(0).getRow(0).getCell(1)
-            cell.cellTypeEnum == CellType.BLANK
+            cell.getCellType() == CellType.BLANK
             cell.stringCellValue == ""
             cell.cellStyle != customStyle
             cell.cellStyle == wb.getCellStyleAt((short)0)

--- a/jxls-poi/src/test/java/org/jxls/examples/AreaListenerDemo.java
+++ b/jxls-poi/src/test/java/org/jxls/examples/AreaListenerDemo.java
@@ -113,7 +113,7 @@ public class AreaListenerDemo {
             CellStyle cellStyle = cell.getCellStyle();
             CellStyle newCellStyle = workbook.createCellStyle();
             newCellStyle.setDataFormat(cellStyle.getDataFormat());
-            newCellStyle.setFont(workbook.getFontAt(cellStyle.getFontIndexAsInt()));
+            newCellStyle.setFont(workbook.getFontAt(cellStyle.getFontIndex()));
             newCellStyle.setFillBackgroundColor(cellStyle.getFillBackgroundColor());
             newCellStyle.setFillForegroundColor(IndexedColors.ORANGE.getIndex());
             // newCellStyle.setFillForegroundColor( cellStyle.getFillForegroundColor());

--- a/jxls-poi/src/test/java/org/jxls/examples/Highlight1Demo.java
+++ b/jxls-poi/src/test/java/org/jxls/examples/Highlight1Demo.java
@@ -90,7 +90,7 @@ public class Highlight1Demo {
             CellStyle cellStyle = cell.getCellStyle();
             CellStyle newCellStyle = workbook.createCellStyle();
             newCellStyle.setDataFormat(cellStyle.getDataFormat());
-            newCellStyle.setFont(workbook.getFontAt(cellStyle.getFontIndexAsInt()));
+            newCellStyle.setFont(workbook.getFontAt(cellStyle.getFontIndex()));
             newCellStyle.setFillBackgroundColor(cellStyle.getFillBackgroundColor());
             newCellStyle.setFillForegroundColor(IndexedColors.ORANGE.getIndex());
             newCellStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);

--- a/jxls-poi/src/test/java/org/jxls/templatebasedtests/IssueB116Test.java
+++ b/jxls-poi/src/test/java/org/jxls/templatebasedtests/IssueB116Test.java
@@ -76,7 +76,7 @@ public class IssueB116Test {
             assertEquals(14.814804, w.getCellValueAsDouble(7 , 3), 0.00000001d);
 
             assertEquals(1.33302663139189, w.getCellValueAsDouble(3, 4), 0.00000000000001d);
-            assertEquals(2.85942651592937, w.getCellValueAsDouble(4, 4), 0.00000000000001d);
+            assertEquals(2.85942651592938, w.getCellValueAsDouble(4, 4), 0.00000000000001d);
             assertEquals(2.12077721602247, w.getCellValueAsDouble(5, 4), 0.00000000000001d);
             assertEquals(3.58175376038052, w.getCellValueAsDouble(6, 4), 0.00000000000001d);
             assertEquals(4.21636867458243, w.getCellValueAsDouble(7, 4), 0.00000000000001d);

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>2.12.1-SNAPSHOT</version>
+		<version>2.13.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/jxls/src/main/java/org/jxls/builder/xls/XlsCommentAreaBuilder.java
+++ b/jxls/src/main/java/org/jxls/builder/xls/XlsCommentAreaBuilder.java
@@ -317,7 +317,8 @@ public class XlsCommentAreaBuilder implements AreaBuilder {
             return null;
         }
         try {
-            Command command = clazz.newInstance();
+            // Used alternative to call default constructor as class.newInstance() is depricated
+            Command command = clazz.getDeclaredConstructor().newInstance();
             for (Map.Entry<String, String> attr : attrMap.entrySet()) {
                 if (!attr.getKey().equals(LAST_CELL_ATTR_NAME)) {
                     Util.setObjectProperty(command, attr.getKey(), attr.getValue(), true);

--- a/jxls/src/main/java/org/jxls/builder/xls/XlsCommentAreaBuilder.java
+++ b/jxls/src/main/java/org/jxls/builder/xls/XlsCommentAreaBuilder.java
@@ -317,7 +317,7 @@ public class XlsCommentAreaBuilder implements AreaBuilder {
             return null;
         }
         try {
-            // Used alternative to call default constructor as class.newInstance() is depricated
+            // Used alternative to call default constructor as class.newInstance() is deprecated
             Command command = clazz.getDeclaredConstructor().newInstance();
             for (Map.Entry<String, String> attr : attrMap.entrySet()) {
                 if (!attr.getKey().equals(LAST_CELL_ATTR_NAME)) {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>2.12.1-SNAPSHOT</version>
+    <version>2.13.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>
@@ -123,6 +123,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>runtime</scope>
-            </dependency>
-            <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>3.3.0</version>


### PR DESCRIPTION
    To Support latest version of Apache Poi - 5..2.3
    1. Modified POM dependencies of Apache POI to 5.2.3 from 4.1.2
    2. Removed dependency ooxml-schemas & added latest version of poi-ooxml
    3. Updated commons-compress version to 1.22 from 1.21
    4. Modified code to remove usage of deprecated functions - setCellType, cellTypeEnum & getFontIndexAsInt
    5. Ensured that all the test cases pass - Double Value in IssueB116Test had to be changed
    6. Changed project version to 2.13.0-SNAPSHOT
    7. Changed build.gradle file for version dependencies - but not tested gradle build