### PR TITLE
#240 table syntax

### DIFF
--- a/jxls-site/docs/changes.md
+++ b/jxls-site/docs/changes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## v3.1.0
+- [#240 Table syntax support for AbstractFormulaProcessor.getFormulaCellRefs()](https://github.com/jxlsteam/jxls/issues/240)
+
 ## v3.0.0
 - Java 17
 - see [migration guide](migration-to-v3-0.html)

--- a/jxls/src/main/java/org/jxls/formula/AbstractFormulaProcessor.java
+++ b/jxls/src/main/java/org/jxls/formula/AbstractFormulaProcessor.java
@@ -23,8 +23,11 @@ import org.jxls.util.CellRefUtil;
  */
 public abstract class AbstractFormulaProcessor implements FormulaProcessor {
     protected static final String regexJointedLookBehind = "(?<!U_\\([^)]{0,100})";
-    public static final String regexCellRef = "([a-zA-Z_]+[a-zA-Z0-9_]*![a-zA-Z]+[0-9]+|(?<!\\d)[a-zA-Z]+[0-9]+|'[^?\\\\/:'*]+'![a-zA-Z]+[0-9]+)";
-    private static final String regexCellRefExcludingJointed = regexJointedLookBehind + regexCellRef;
+    public static final String regexCellRef = "([a-zA-Z_]+[a-zA-Z0-9_]*![a-zA-Z]+[0-9]+" // sheet + cell syntax
+            + "|[a-zA-Z_]+[a-zA-Z0-9_]*\\[[a-zA-Z0-9 _]+\\]" // table syntax (#240)
+            + "|(?<!\\d)[a-zA-Z]+[0-9]+" // cell syntax
+            + "|'[^?\\\\/:'*]+'![a-zA-Z]+[0-9]+)"; // 'sheet name' + cell syntax
+    public static final String regexCellRefExcludingJointed = regexJointedLookBehind + regexCellRef;
     private static final Pattern regexCellRefExcludingJointedPattern = Pattern.compile(regexCellRefExcludingJointed);
     private static final Pattern regexCellRefPattern = Pattern.compile(regexCellRef);
     private static final String regexJointedCellRef = "U_\\([^\\)]+\\)";

--- a/jxls/src/test/java/org/jxls/util/UtilTest.java
+++ b/jxls/src/test/java/org/jxls/util/UtilTest.java
@@ -39,7 +39,7 @@ public class UtilTest {
         assertEquals(sheetsNameOfMultiSheetTemplate, singletonList("areaWithMultiSheetOutput"));
     }
     
-// #240 not part of v2.13.0    @Test
+    @Test
     public void test_getFormulaCellRefs_tableSyntax() {
         // Test
         String table = "_tabu";
@@ -51,7 +51,7 @@ public class UtilTest {
         assertEquals("_tabu[ 1 column b]", formulaCellRefs.get(0));
     }
 
-// #240 not part of v2.13.0    @Test
+    @Test
     public void test_getFormulaCellRefs_tableSyntax2() {
         // Test
         String formula = "FUNC(one[AB CD],two[123], -1, three[c])";


### PR DESCRIPTION
This is my second attempt to solve #240.

The regular expression must be earlier in regexCellRef. Inside [...] I don't use .+

instead I use [a-zA-Z0-9 _]+