### PR TITLE
commons-logging 1.3.0 -> 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'org.owasp.dependencycheck'
     
-    version = '3.0.0-a007-SNAPSHOT'
+    version = '3.1.0-a195-SNAPSHOT'
     group = 'org.jxls'
     
     repositories {
@@ -26,7 +26,7 @@ subprojects {
     dependencies {
         testImplementation 'org.junit.vintage:junit-vintage-engine:5.10.1'
         testImplementation 'org.mockito:mockito-core:4.11.0'
-        testRuntimeOnly 'commons-logging:commons-logging:1.3.0'
+        testRuntimeOnly 'commons-logging:commons-logging:1.3.5'
     }
     
     java {

--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.5</version>
             <scope>test</scope>
         </dependency>
 		<dependency>

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.5</version>
             <scope>test</scope>
         </dependency>
 		<dependency>


### PR DESCRIPTION
test scope

During the alpha test, I noticed that we are not using the latest version here.