### PR TITLE
3.1.0 release

### DIFF
--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>

--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>

--- a/jxls-site/pom.xml
+++ b/jxls-site/pom.xml
@@ -5,14 +5,14 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-site</artifactId>
     <packaging>jar</packaging>
-    <version>2.14.0</version>
+    <version>3.1.0</version>
     <name>JXLS</name>
     <url>http://jxls.sf.net/</url>
 
     <properties>
-        <jxlsVersion>2.14.0</jxlsVersion>
-        <jxlsPoiVersion>2.14.0</jxlsPoiVersion>
-        <jxlsReaderVersion>2.0.6</jxlsReaderVersion>
+        <jxlsVersion>3.1.0</jxlsVersion>
+        <jxlsPoiVersion>3.1.0</jxlsPoiVersion>
+        <jxlsReaderVersion>2.1.0</jxlsReaderVersion>
         <copyrightClass>pull-right</copyrightClass>
     </properties>
 

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.0.1-SNAPSHOT</version>
+		<version>3.1.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.1.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:http://github.com/jxlsteam/jxls.git</connection>
         <developerConnection>scm:git:https://github.com/jxlsteam/jxls.git</developerConnection>
         <url>https://github.com/jxlsteam/jxls.git</url>
-        <tag>HEAD</tag>
+        <tag>3.1.0</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:http://github.com/jxlsteam/jxls.git</connection>
         <developerConnection>scm:git:https://github.com/jxlsteam/jxls.git</developerConnection>
         <url>https://github.com/jxlsteam/jxls.git</url>
-        <tag>3.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
     </licenses>
     <developers>
         <developer>
-            <name>Leonid Vysochyn</name>
-            <email>leonate@gmail.com</email>
+            <name>Leo Vysochyn</name>
         </developer>
     </developers>
 
@@ -171,7 +170,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
@@ -227,7 +226,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
- Updated project publishing configuration to use  [Publish OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) due to [OSSRH EOL](https://central.sonatype.org/pages/ossrh-eol/)
- Released `jxls-3.1.0` and `jxls-poi-3.1.0` packages to Maven central 
- Set `3.1.1-SNAPSHOT` as the current development version in POMs
- The `3.1.0` release documentation was built with `sitegen` and published at https://jxls.sourceforge.net/