### PR TITLE
Built-in Java Record property access for JEXL expressions

### DIFF
--- a/jxls/src/main/java/org/jxls/expression/JexlExpressionEvaluator.java
+++ b/jxls/src/main/java/org/jxls/expression/JexlExpressionEvaluator.java
@@ -99,7 +99,10 @@ public class JexlExpressionEvaluator implements ExpressionEvaluator {
         Map<String, JexlEngine> map = jexlThreadLocal.get();
         JexlEngine ret = map.get(key);
         if (ret == null) {
-            ret = new JexlBuilder().silent(silent).strict(strict).permissions(permissions.getJexlPermissions()).create();
+            ret = new JexlBuilder().silent(silent).strict(strict)
+                    .permissions(permissions.getJexlPermissions())
+                    .strategy(new RecordAwareStrategy())
+                    .create();
             map.put(key, ret);
         }
         return ret;

--- a/jxls/src/main/java/org/jxls/expression/JexlExpressionEvaluatorNoThreadLocal.java
+++ b/jxls/src/main/java/org/jxls/expression/JexlExpressionEvaluatorNoThreadLocal.java
@@ -35,7 +35,10 @@ public class JexlExpressionEvaluatorNoThreadLocal implements ExpressionEvaluator
     }
 
     public JexlExpressionEvaluatorNoThreadLocal(boolean silent, boolean strict, JexlPermissions jexlPermissions) {
-        this.jexl = new JexlBuilder().silent(silent).strict(strict).permissions(jexlPermissions).create();
+        this.jexl = new JexlBuilder().silent(silent).strict(strict)
+                .permissions(jexlPermissions)
+                .strategy(new RecordAwareStrategy())
+                .create();
     }
 
     public JexlExpressionEvaluatorNoThreadLocal(boolean silent, boolean strict, JxlsJexlPermissions permissions, String expression) {

--- a/jxls/src/main/java/org/jxls/expression/RecordAwareStrategy.java
+++ b/jxls/src/main/java/org/jxls/expression/RecordAwareStrategy.java
@@ -1,0 +1,124 @@
+package org.jxls.expression;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.JexlException;
+import org.apache.commons.jexl3.JexlOperator;
+import org.apache.commons.jexl3.introspection.JexlPropertyGet;
+import org.apache.commons.jexl3.introspection.JexlPropertySet;
+import org.apache.commons.jexl3.introspection.JexlUberspect;
+
+/**
+ * A {@link JexlUberspect.ResolverStrategy} that extends the standard POJO resolution
+ * with Java Record support.
+ * 
+ * <p>Standard JEXL introspection resolves {@code obj.prop} by looking for {@code getProp()} or
+ * {@code isProp()} methods (JavaBeans convention). Java Records use accessor methods named
+ * {@code prop()} without any prefix, so the standard resolution fails.</p>
+ * 
+ * <p>This strategy appends a custom {@link RecordPropertyResolver} after the standard POJO
+ * resolvers. When all standard resolvers fail and the object is a {@link java.lang.Record},
+ * it attempts to find a no-argument method with exactly the property name.</p>
+ */
+public class RecordAwareStrategy implements JexlUberspect.ResolverStrategy {
+
+    private static final RecordPropertyResolver RECORD_RESOLVER = new RecordPropertyResolver();
+
+    @Override
+    public List<JexlUberspect.PropertyResolver> apply(final JexlOperator operator, final Object obj) {
+        List<JexlUberspect.PropertyResolver> resolvers = new ArrayList<>(JexlUberspect.POJO);
+        resolvers.add(RECORD_RESOLVER);
+        return resolvers;
+    }
+
+    /**
+     * A {@link JexlUberspect.PropertyResolver} that handles Java Record component accessors.
+     * <p>When the object is a {@link Record}, it looks for a no-argument method
+     * with the exact property name (e.g. {@code name()} for property {@code name}).
+     * For property sets, it returns {@code null} since records are immutable.</p>
+     */
+    private static final class RecordPropertyResolver implements JexlUberspect.PropertyResolver {
+
+        @Override
+        public JexlPropertyGet getPropertyGet(final JexlUberspect uber, final Object obj,
+                                              final Object identifier) {
+            if (obj instanceof Record) {
+                String propertyName = identifier.toString();
+                try {
+                    Method method = obj.getClass().getMethod(propertyName);
+                    if (method.getParameterCount() == 0 && method.getReturnType() != void.class) {
+                        return new RecordPropertyGet(obj.getClass(), method, propertyName);
+                    }
+                } catch (final NoSuchMethodException e) {
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public JexlPropertySet getPropertySet(final JexlUberspect uber, final Object obj,
+                                              final Object identifier, final Object arg) {
+            if (obj instanceof Record) {
+                return null;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * A {@link JexlPropertyGet} that invokes a record component accessor method.
+     */
+    private static final class RecordPropertyGet implements JexlPropertyGet {
+
+        private final Class<?> objectClass;
+        private final Method method;
+        private final String propertyName;
+
+        RecordPropertyGet(final Class<?> objectClass, final Method method, final String propertyName) {
+            this.objectClass = objectClass;
+            this.method = method;
+            this.propertyName = propertyName;
+        }
+
+        @Override
+        public Object invoke(final Object obj) throws Exception {
+            return method.invoke(obj);
+        }
+
+        @Override
+        public boolean isCacheable() {
+            return true;
+        }
+
+        @Override
+        public boolean tryFailed(final Object rval) {
+            return rval == JexlEngine.TRY_FAILED;
+        }
+
+        @Override
+        public Object tryInvoke(final Object obj, final Object key)
+                throws JexlException.TryFailed {
+            if (obj != null
+                    && objectClass.equals(obj.getClass())
+                    && propertyName.equals(key)) {
+                try {
+                    return method.invoke(obj);
+                } catch (final IllegalAccessException | IllegalArgumentException e) {
+                    return JexlEngine.TRY_FAILED;
+                } catch (final InvocationTargetException e) {
+                    throw JexlException.tryFailed(e);
+                }
+            }
+            return JexlEngine.TRY_FAILED;
+        }
+
+        @Override
+        public String toString() {
+            return "RecordPropertyGet[" + objectClass.getSimpleName() + "." + propertyName + "()]";
+        }
+    }
+}

--- a/jxls/src/test/java/org/jxls/expression/JexlExpressionEvaluatorNoThreadLocalRecordTest.java
+++ b/jxls/src/test/java/org/jxls/expression/JexlExpressionEvaluatorNoThreadLocalRecordTest.java
@@ -1,0 +1,68 @@
+package org.jxls.expression;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Mirrors {@link JexlExpressionEvaluatorNoThreadLocalTest} using a Java Record instead of {@link Dummy}.
+ * is built into {@link JexlExpressionEvaluatorNoThreadLocal} by default.
+ *
+ * @see JexlExpressionEvaluatorNoThreadLocalTest
+ */
+public class JexlExpressionEvaluatorNoThreadLocalRecordTest {
+
+    /** Same record as in {@link JexlExpressionEvaluatorRecordTest}. */
+    public record DummyRecord(String strValue, int intValue) {
+    }
+
+    @Before
+    public void setUp() {
+        JexlExpressionEvaluatorNoThreadLocal.clear();
+    }
+
+    @After
+    public void tearDown() {
+        JexlExpressionEvaluatorNoThreadLocal.clear();
+    }
+
+    @Test
+    public void recordPropertyAccess() {
+        String expression = "dummy.intValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("dummy", new DummyRecord("hello", 42));
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluatorNoThreadLocal();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals(42, result);
+    }
+
+    @Test
+    public void recordArithmeticWithProperty() {
+        String expression = "2*x + dummy.intValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("x", Integer.valueOf(2));
+        vars.put("dummy", new DummyRecord("hello", 3));
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluatorNoThreadLocal();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals("7", result.toString());
+    }
+
+    @Test
+    public void recordStringProperty() {
+        String expression = "dummy.strValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("dummy", new DummyRecord("hello", 42));
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluatorNoThreadLocal();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals("hello", result);
+    }
+}

--- a/jxls/src/test/java/org/jxls/expression/JexlExpressionEvaluatorRecordTest.java
+++ b/jxls/src/test/java/org/jxls/expression/JexlExpressionEvaluatorRecordTest.java
@@ -1,0 +1,68 @@
+package org.jxls.expression;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Mirrors {@link JexlExpressionEvaluatorTest} using a Java Record instead of {@link Dummy}.
+ * {@link JexlExpressionEvaluator} by default.
+ *
+ * @see JexlExpressionEvaluatorTest
+ */
+public class JexlExpressionEvaluatorRecordTest {
+
+    /** Record equivalent of {@link Dummy}: {@code strValue} / {@code intValue} via accessor methods. */
+    public record DummyRecord(String strValue, int intValue) {
+    }
+
+    @Before
+    public void setUp() {
+        JexlExpressionEvaluator.clear();
+    }
+
+    @After
+    public void tearDown() {
+        JexlExpressionEvaluator.clear();
+    }
+
+    @Test
+    public void recordPropertyAccess() {
+        String expression = "dummy.intValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("dummy", new DummyRecord("hello", 42));
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluator();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals(42, result);
+    }
+
+    @Test
+    public void recordArithmeticWithProperty() {
+        String expression = "2*x + dummy.intValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("x", Integer.valueOf(2));
+        vars.put("dummy", new DummyRecord("hello", 3));                  // same arithmetic as original but with record
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluator();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals("7", result.toString());                            // 2*2 + 3 = 7, same as original simple2VarExpression
+    }
+
+    @Test
+    public void recordStringProperty() {
+        String expression = "dummy.strValue";
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("dummy", new DummyRecord("hello", 42));
+        ExpressionEvaluator expressionEvaluator = new JexlExpressionEvaluator();
+        Object result = expressionEvaluator.evaluate(expression, vars);
+        assertNotNull(result);
+        assertEquals("hello", result);
+    }
+}


### PR DESCRIPTION
# Problem

Users are forced to use method-call syntax `${data.prop()}` for records, breaking consistency with standard JavaBean templates.

# Solution

`RecordAwareStrategy` implements `JexlUberspect.ResolverStrategy`, appends a custom `RecordPropertyResolver` as final fallback. When target is `java.lang.Record`, the fallback resolver reflects for a no-arg method with exactly the property name.
