### PR TITLE
Fallback to mutable copy when list is immutable on orderBy

### DIFF
--- a/jxls/src/main/java/org/jxls/command/EachCommand.java
+++ b/jxls/src/main/java/org/jxls/command/EachCommand.java
@@ -304,7 +304,7 @@ public class EachCommand extends AbstractCommand {
         Iterable<?> itemsCollection = null;
         try {
             itemsCollection = transformToIterableObject(items, context);
-            orderCollection(itemsCollection);
+            itemsCollection = orderCollection(itemsCollection);
         } catch (Exception e) {
             getLogger().handleEvaluationException(e, cellRef.toString(), items);
             itemsCollection = Collections.emptyList();
@@ -330,12 +330,29 @@ public class EachCommand extends AbstractCommand {
         return size;
     }
     
-    private void orderCollection(Iterable<?> itemsCollection) {
+    private Iterable<?> orderCollection(Iterable<?> itemsCollection) {
         if (itemsCollection instanceof List<?> itemsList && orderBy != null && !orderBy.trim().isEmpty()) {
             List<String> orderByProps = Arrays.asList(orderBy.split(","))
                     .stream().map(f -> removeVarPrefix(f, var)).collect(Collectors.toList());
-            itemsList.sort(new OrderByComparator<>(orderByProps));
+            OrderByComparator<Object> comparator = new OrderByComparator<>(orderByProps);
+            if (isKnownImmutableList(itemsList)) {
+                List<Object> mutableCopy = new ArrayList<>(itemsList);
+                mutableCopy.sort(comparator);
+                return mutableCopy;
+            } else {
+                @SuppressWarnings("unchecked")
+                List<Object> mutableList = (List<Object>) itemsList;
+                mutableList.sort(comparator);
+            }
         }
+        return itemsCollection;
+    }
+
+    private static boolean isKnownImmutableList(List<?> list) {
+        String className = list.getClass().getName();
+        return className.startsWith("java.util.ImmutableCollections$")
+                || className.startsWith("java.util.Collections$Unmodifiable")
+                || className.equals("java.util.Collections$SingletonList");
     }
 
     private Iterable<?> filter(Context context, Iterable<?> itemsCollection, String selectExpression) {


### PR DESCRIPTION
# Motivation

In our codebase we commonly use `Stream.toList()` as the idiomatic terminal operation for processed data passed to JXLS templates:

```java
List<Employee> employees = records.stream()
    .filter(r -> r.isActive())
    .map(Employee::doSth)
    .toList();  // immutable
data.put("employees", employees);
```

If someone later modifies the template to add orderBy on `jx:each` (e.g. `orderBy="e.name"`), the system breaks at runtime with:

```
java.lang.UnsupportedOperationException
    at java.base/java.util.ImmutableCollections.uoe(...)
    at ...EachCommand.orderCollection(EachCommand.java:337)
```

The failure is silent until that specific template + data combination is hit in production.  There is no compile-time warning and no obvious link between the template change and the Java exception.

# Solution

Detect known JDK immutable list types by class name and create a mutable ArrayList copy for sorting:

| List Type | Detected By | Action |
|-----------|-------------|--------|
| `Stream.toList()`, `List.of()`, `List.copyOf()` | `java.util.ImmutableCollections$` prefix | Copy → sort |
| `Collections.unmodifiableList()` | `java.util.Collections$Unmodifiable` prefix | Copy → sort |
| `Collections.singletonList()` | exact class name match | Copy → sort |
| `ArrayList`, `LinkedList`, etc. | (none of the above) | Sort in-place (unchanged) |
