### PR TITLE
3.2.0 release

### DIFF
--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>

--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>

--- a/jxls-poi/pom.xml
+++ b/jxls-poi/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls-poi</artifactId>

--- a/jxls-site/deploy-site.sh
+++ b/jxls-site/deploy-site.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Deploy the generated Maven site to the JXLS SourceForge project website.
+# Run this file with bash:
+# bash ./deploy-site.sh
+#
+# Prerequisites:
+#   1. Generate the site into ./target/site folder
+#   2. Configure ~/.ssh/config with:
+#
+#        Host sourceforge-web
+#            HostName web.sourceforge.net
+#            User <your-sourceforge-username>
+#
+#   3. Make sure SSH authentication to SourceForge works:
+#
+#        ssh sourceforge-web
+#
+# The SourceForge web host provides a restricted file-transfer shell, so
+# Maven's `site:deploy` is not used here. We use the native `scp` client.
+
+scp -r ./target/site/. sourceforge-web:/home/project-web/jxls/htdocs/

--- a/jxls-site/docs/vars
+++ b/jxls-site/docs/vars
@@ -1,2 +1,2 @@
-version=3.1.0
-jexl_version=3.6.0
+version=3.2.0
+jexl_version=3.6.2

--- a/jxls-site/pom.xml
+++ b/jxls-site/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-site</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
     <name>JXLS</name>
     <url>http://jxls.sf.net/</url>
 

--- a/jxls-site/pom.xml
+++ b/jxls-site/pom.xml
@@ -10,8 +10,8 @@
     <url>http://jxls.sf.net/</url>
 
     <properties>
-        <jxlsVersion>3.1.0</jxlsVersion>
-        <jxlsPoiVersion>3.1.0</jxlsPoiVersion>
+        <jxlsVersion>3.2.0</jxlsVersion>
+        <jxlsPoiVersion>3.2.0</jxlsPoiVersion>
         <jxlsReaderVersion>2.1.0</jxlsReaderVersion>
         <copyrightClass>pull-right</copyrightClass>
     </properties>
@@ -85,12 +85,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <site>
-            <id>jxls.sf.net</id>
-            <url>scp://shell.sourceforge.net/home/project-web/jxls/htdocs</url>
-        </site>
-    </distributionManagement>
-
 </project>

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/jxls/pom.xml
+++ b/jxls/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.jxls</groupId>
 		<artifactId>jxls-project</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jxls</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:http://github.com/jxlsteam/jxls.git</connection>
         <developerConnection>scm:git:https://github.com/jxlsteam/jxls.git</developerConnection>
         <url>https://github.com/jxlsteam/jxls.git</url>
-        <tag>HEAD</tag>
+        <tag>3.2.0</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:http://github.com/jxlsteam/jxls.git</connection>
         <developerConnection>scm:git:https://github.com/jxlsteam/jxls.git</developerConnection>
         <url>https://github.com/jxlsteam/jxls.git</url>
-        <tag>3.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jxls</groupId>
     <artifactId>jxls-project</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Small library for Excel generation based on XLS templates</description>
     <url>http://jxls.sf.net</url>


### PR DESCRIPTION
Jxls 3.2.0 release is pushed to Maven Central.
The doc site https://jxls.sourceforge.net/ is updated to the latest version.
